### PR TITLE
Load prependers in alphabetical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ Animals::Dog.new.bark # => 'Woof!'
 
 ### Autoloading prependers
 
-If you don't want to include `Prependers::Prepender`, you can also autoload prependers from a path.
+If you don't want to include `Prependers::Prepender`, you can also autoload prependers from a path,
+they will be loaded in alphabetical order.
+
 Here's the previous example, but with autoloading:
 
 ```ruby

--- a/lib/prependers/loader.rb
+++ b/lib/prependers/loader.rb
@@ -10,7 +10,7 @@ module Prependers
     end
 
     def load
-      Dir.glob("#{base_path}/**/*.rb") do |path|
+      Dir.glob("#{base_path}/**/*.rb").sort.each do |path|
         absolute_path = Pathname.new(File.expand_path(path))
         relative_path = absolute_path.relative_path_from(base_path)
 

--- a/spec/prependers/loader_spec.rb
+++ b/spec/prependers/loader_spec.rb
@@ -8,12 +8,15 @@ RSpec.describe Prependers::Loader do
       before do
         class Lion; end
         Dir.glob("#{path}/**/*.rb") { |f| require(f) }
+        described_class.new(path).load
       end
 
       it 'loads the prependers' do
-        described_class.new(path).load
-
         expect(Lion.new.roar).to eq('Roar!')
+      end
+
+      it 'loads in alphabetical order' do
+        expect(Lion.ancestors.first).to eq(Lion::AddTail)
       end
     end
 
@@ -23,12 +26,15 @@ RSpec.describe Prependers::Loader do
       before do
         class Mouse; end
         Dir.glob("#{path}/**/*.rb") { |f| require(f) }
+        described_class.new(path, namespace: Acme).load
       end
 
       it 'loads the prependers' do
-        described_class.new(path, namespace: Acme).load
-
         expect(Mouse.new.squeak).to eq('Squeak!')
+      end
+
+      it 'loads in alphabetical order' do
+        expect(Mouse.ancestors.first).to eq(Acme::Mouse::AddTail)
       end
     end
   end

--- a/spec/support/files/prependers/with_namespace/acme/mouse/add_tail.rb
+++ b/spec/support/files/prependers/with_namespace/acme/mouse/add_tail.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Mouse; end
+
+module Acme
+  module Mouse
+    module AddTail
+      def tail
+        'Move!'
+      end
+    end
+  end
+end

--- a/spec/support/files/prependers/without_namespace/lion/add_tail.rb
+++ b/spec/support/files/prependers/without_namespace/lion/add_tail.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Lion
+  module AddTail
+    def tail
+      'Move!'
+    end
+  end
+end


### PR DESCRIPTION
Every time Ruby runs `Dir.glob` the sort order is preserved every
time... except the same order is not guaranteed across different
operating systems.

For this reason I think we should sort everything alphabetically when
loading prepeders so that we get the same result across different
operating systems.

The specs check for `ancestors` on the class (what's loaded last is the
first in the array of ancestors).