### PR TITLE
Automatically prepend ClassMethods to singleton_class

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,28 @@ end
 Animals::Dog.new.bark # => 'Woof!'
 ```
 
+### Extending class methods
+
+If you want to extend a module's class methods, you can define a `ClassMethods` module in your
+prepender:
+
+```ruby
+module Animals::Dog::AddBarking
+  include Prependers::Prepender.new
+
+  module ClassMethods
+    def family
+      puts 'Canids'
+    end
+  end
+end
+
+Animals::Dog.family # => 'Canids'
+```
+
+As you can see, the `ClassMethods` module has automagically been `prepend`ed to the `Animals::Dog`'s
+singleton class.
+
 ### Autoloading prependers
 
 If you don't want to include `Prependers::Prepender`, you can also autoload prependers from a path,

--- a/lib/prependers/prepender.rb
+++ b/lib/prependers/prepender.rb
@@ -2,6 +2,8 @@
 
 module Prependers
   class Prepender < Module
+    CLASS_METHODS_MODULE_NAME = 'ClassMethods'
+
     attr_reader :namespace
 
     def initialize(namespace = nil)
@@ -17,6 +19,10 @@ module Prependers
 
       prepended_module = Object.const_get(prepended_module_name)
       prepended_module.prepend base
+
+      if base.const_defined?(CLASS_METHODS_MODULE_NAME)
+        prepended_module.singleton_class.prepend base.const_get(CLASS_METHODS_MODULE_NAME)
+      end
     end
   end
 end

--- a/spec/prependers/prepender_spec.rb
+++ b/spec/prependers/prepender_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe Prependers::Prepender do
       module Dog::AddBarking # rubocop:disable Style/ClassAndModuleChildren
         include Prependers::Prepender.new
 
+        module ClassMethods
+          def bark
+            'Class woof!'
+          end
+        end
+
         def bark
           'Woof!'
         end
@@ -16,6 +22,10 @@ RSpec.describe Prependers::Prepender do
 
     it 'prepends the base module to the prepended module' do
       expect(Dog.new.bark).to eq('Woof!')
+    end
+
+    it "prepends the ClassMethods module to the prepended module's singleton class" do
+      expect(Dog.bark).to eq('Class woof!')
     end
   end
 
@@ -28,6 +38,12 @@ RSpec.describe Prependers::Prepender do
           module AddMeow
             include Prependers::Prepender.new(Acme)
 
+            module ClassMethods
+              def meow
+                'Class meow!'
+              end
+            end
+
             def meow
               'Meow!'
             end
@@ -38,6 +54,10 @@ RSpec.describe Prependers::Prepender do
 
     it 'prepends the base module to the prepended module' do
       expect(Cat.new.meow).to eq('Meow!')
+    end
+
+    it "prepends the ClassMethods module to the prepended module's singleton class" do
+      expect(Cat.meow).to eq('Class meow!')
     end
   end
 end


### PR DESCRIPTION
Closes #4.

If a prepender defines a `ClassMethods` module, it will now be automatically `prepend`ed to the prepended module's `singleton_class`.