### PR TITLE
Add Rails setup helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Added `Prependers.setup_for_rails` helper for Rails integration
+- Added support for Rails 6 and Zeitwerk 
+
 ## [0.2.0] - 2019-07-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you want to extend a module's class methods, you can define a `ClassMethods` 
 prepender:
 
 ```ruby
-module Animals::Dog::AddBarking
+module Animals::Dog::AddFamily
   include Prependers::Prepender.new
 
   module ClassMethods
@@ -134,21 +134,11 @@ To use prependers in your Rails app, simply create them under `app/prependers/mo
 `app/prependers/controllers` etc. and add the following to your `config/application.rb`:
 
 ```ruby
-config.to_prepare do
-  Dir.glob(Rails.root.join('app', 'prependers', '**', '*.rb')) do |c|
-    Rails.configuration.cache_classes ? require(c) : load(c)
-  end
-
-  prepender_paths = Dir.glob(Rails.root.join('app', 'prependers', '*')).map do |p|
-    File.expand_path(p, __FILE__)
-  end
-
-  Prependers.load_paths(*prepender_paths)
-end
+Prependers.setup_for_rails
 ```
 
-If you want to use a namespace, just pass the `:namespace` option to `#load_paths` and name your
-files and modules accordingly.
+If you want to use a namespace, just pass the `:namespace` option to `#setup_for_rails` and name
+your files and modules accordingly.
 
 ## Development
 

--- a/lib/prependers.rb
+++ b/lib/prependers.rb
@@ -8,8 +8,20 @@ require "prependers/loader"
 module Prependers
   class << self
     def load_paths(*paths, **options)
-      Array(paths).each do |path|
+      paths.flatten.each do |path|
         Loader.new(path, options).load
+      end
+    end
+
+    def setup_for_rails(load_options = {})
+      prependers_directories = Rails.root.join('app', 'prependers').glob('*')
+
+      Rails.application.config.tap do |config|
+        config.autoload_paths += prependers_directories
+
+        config.to_prepare do
+          Prependers.load_paths(prependers_directories, load_options)
+        end
       end
     end
   end


### PR DESCRIPTION
Adds a helper to set up the Rails integration without copy-pasting code, and adds support for Rails 6 and Zeitwerk.