### PR TITLE
Separate Positional and Keyword Arguments

### DIFF
--- a/lib/prependers.rb
+++ b/lib/prependers.rb
@@ -23,7 +23,7 @@ module Prependers
       config.autoload_paths += prependers_directories
 
       config.to_prepare do
-        Prependers.load_paths(prependers_directories, load_options)
+        Prependers.load_paths(prependers_directories, **load_options)
       end
     end
   end


### PR DESCRIPTION
Add Double Splat to load_paths Call
In Ruby 3.0, positional arguments and keyword arguments were separated.
In Ruby 3, a method delegating all arguments must explicitly delegate
keyword arguments in addition to positional arguments.

In most cases, we can avoid the incompatibility by adding the double
splat operator. It explicitly specifies passing keyword arguments
instead of a Hash object.

Without this fix, applications utilizing Ruby 3+ would pass the options
hash with `prependers_directories`

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/